### PR TITLE
Normalise aiddata columns

### DIFF
--- a/oda_reader/__init__.py
+++ b/oda_reader/__init__.py
@@ -18,6 +18,7 @@ from oda_reader.dac1 import download_dac1
 from oda_reader.dac2a import download_dac2a
 from oda_reader.multisystem import download_multisystem, bulk_download_multisystem
 from oda_reader.crs import download_crs, bulk_download_crs, download_crs_file
+from oda_reader.aiddata import download_aiddata
 from oda_reader.tools import get_available_filters
 
 enforce_cache_limits()
@@ -32,6 +33,7 @@ __all__ = [
     "download_crs",
     "bulk_download_crs",
     "download_crs_file",
+    "download_aiddata",
     "get_available_filters",
     "enforce_cache_limits",
     "enable_cache",

--- a/oda_reader/aiddata.py
+++ b/oda_reader/aiddata.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+import pandas as pd
+
+from oda_reader._cache import cache_info
+from oda_reader.common import logger
+
+from oda_reader.download.download_tools import (
+    bulk_download_aiddata,
+)
+
+@cache_info
+def download_aiddata(
+    start_year: int | None = None,
+    end_year: int | None = None,
+    filters: dict | None = None,
+    pre_process: bool = True,
+    dotstat_codes: bool = True,
+    as_grant_equivalent: bool = False,
+) -> pd.DataFrame:
+    """
+    Download the AidData from the website.
+
+    Args:
+        start_year (int): The start year of the data to download. Optional
+        end_year (int): The end year of the data to download. Optional
+        filters (dict): Optional filters to pass to the download.
+        pre_process (bool): Whether to preprocess the data. Defaults to True.
+        Preprocessing makes it comply with the .stat schema.
+        dotstat_codes (bool): Whether to convert the donor codes to the .stat schema.
+        as_grant_equivalent (bool): Whether to download the grant equivalent data
+        instead of flows.
+    Returns:
+        pd.DataFrame: The CRS data.
+
+    """
+
+    # Inform download is about to start
+    logger.info(
+        "Downloading AidData. This may take a while...\n"
+    )
+
+    if filters is None:
+        filters = {}
+
+    # Warn about duplicates
+    if filters.get("microdata") is False:
+        warning_message = "\nYou have requested aggregates.\n"
+        warnings = [w for w in ("channel", "modality") if w not in filters]
+
+        if warnings:
+            warning_message += "\n".join(
+                f"Unless you specify {w}: '_T', the data will contain duplicates."
+                for w in warnings
+            )
+
+        logger.warning(warning_message)
+
+    df = bulk_download_aiddata()
+    
+    # TODO: Clean data and standardize column and variable names 
+    # for interoperability with OECD data.
+    # Select years based on start_year and end_year
+	# df = clean_raw_df(df)
+
+    # download(
+    #     version="crs",
+    #     dataflow_id=DATAFLOW_ID if not as_grant_equivalent else DATAFLOW_ID_GE,
+    #     dataflow_version=dataflow_version,
+    #     start_year=start_year,
+    #     end_year=end_year,
+    #     filters=filters,
+    #     pre_process=pre_process,
+    #     dotstat_codes=dotstat_codes,
+    # )
+
+    # remove columns where all rows are NaN
+    df = df.dropna(axis=1, how="all")
+
+    return df

--- a/oda_reader/download/download_tools.py
+++ b/oda_reader/download/download_tools.py
@@ -247,8 +247,13 @@ def _save_or_return_excel_files_from_content(
 
     # Open the content as a zip file and extract the parquet files
     with zipfile.ZipFile(io.BytesIO(response_content)) as z:
-        # Find all Excel files in the zip archive
-        excel_files = [name for name in z.namelist() if name.endswith(".xlsx")]
+        # Find all Excel files in the zip archive and filter out those with unreadable format
+        excel_files = [
+            name for name in z.namelist()
+            if name.endswith(".xlsx")
+               and not name.startswith("__MACOSX/")
+               and not name.split("/")[-1].startswith("._")
+        ]
 
         # If save_to_path is provided, save the files to the path
         if save_to_path:
@@ -263,7 +268,7 @@ def _save_or_return_excel_files_from_content(
 
         # If save_to_path is not provided, return the DataFrames
         logger.info(f"Reading {len(excel_files)} Excel files.")
-        return [pd.read_excel(z.open(file)) for file in excel_files]
+        return [pd.read_excel(z.open(file), sheet_name="GCDF_3.0") for file in excel_files]
 
 def bulk_download_parquet(
     file_id: str, save_to_path: Path | str | None = None, is_txt: bool = False
@@ -320,7 +325,7 @@ def bulk_download_parquet(
 
     return None
 
-def bulk_download_aiddata(
+def  bulk_download_aiddata(
     save_to_path: Path | str | None = None
 ) -> pd.DataFrame | None:
     """Download data from the AidData data website.

--- a/oda_reader/schemas/mappings/aidData_schema.json
+++ b/oda_reader/schemas/mappings/aidData_schema.json
@@ -1,0 +1,758 @@
+{
+  "AidData Record ID": {
+    "name": "aiddata_id",
+    "type": "string[pyarrow]",
+    "keep": false,
+    "bool": false
+  },
+  "Recommended For Aggregates": {
+    "name": "recommended_for_aggregates",
+    "type": "string[pyarrow]",
+    "keep": false,
+    "bool": true
+  },
+  "AidData Parent ID": {
+    "name": "aiddata_parent_id",
+    "type": "string[pyarrow]",
+    "keep": false,
+    "bool": false
+  },
+  "Umbrella": {
+    "name": "umbrella",
+    "type": "string[pyarrow]",
+    "keep": false,
+    "bool": true
+  },
+  "Financier Country": {
+    "name": "donor_name",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Recipient": {
+    "name": "recipient_name",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Recipient ISO-3": {
+    "name": "recipient_iso3",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Recipient Region": {
+    "name": "region_name",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Commitment Year": {
+    "name": "commitment_year",
+    "type": "int32[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Implementation Start Year": {
+    "name": "implementation_start_year",
+    "type": "int32[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Completion Year": {
+    "name": "completion_year",
+    "type": "int32[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Title": {
+    "name": "project_title",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Description": {
+    "name": "long_description",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Staff Comments": {
+    "name": "staff_comments",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Status": {
+    "name": "project_status",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Intent": {
+    "name": "project_intent",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Flow Type": {
+    "name": "flow_type",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Flow Type Simplified": {
+    "name": "flow_type_simplified",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "OECD ODA Concessionality Threshold": {
+    "name": "oda_concessionality_threshold",
+    "type": "float64[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Flow Class": {
+    "name": "flow_class",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Sector Code": {
+    "name": "sector_code",
+    "type": "int32[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Sector Name": {
+    "name": "sector_name",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Infrastructure": {
+    "name": "infrastructure",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "COVID": {
+    "name": "covid",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Funding Agencies": {
+    "name": "donor_agencies_name",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Funding Agencies Type": {
+    "name": "donor_agencies_type",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Co-financed": {
+    "name": "co_financed",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Co-financing Agencies": {
+    "name": "co_financing_agencies_name",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Co-financing Agencies Type": {
+    "name": "co_financing_agencies_type",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Direct Receiving Agencies": {
+    "name": "direct_recipient_agencies_name",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Direct Receiving Agencies Type": {
+    "name": "direct_recipient_agencies_type",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Indirect Receiving Agencies": {
+    "name": "indirect_recipient_agencies_name",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Indirect Receiving Agencies Type": {
+    "name": "indirect_recipient_agencies_type",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "On-lending": {
+    "name": "on_lending",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Implementing Agencies": {
+    "name": "implementing_agencies_name",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Implementing Agencies Type": {
+    "name": "implementing_agencies_type",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Guarantee Provided": {
+    "name": "guarantee_provided",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Guarantor": {
+    "name": "guarantor_name",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Guarantor Agency Type": {
+    "name": "guarantor_type",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Insurance Provided": {
+    "name": "insurance_provided",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Insurance Provider": {
+    "name": "insurance_provider_name",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Insurance Provider Agency Type": {
+    "name": "insurance_provider_type",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Collateralized": {
+    "name": "collateralized",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Collateral Provider": {
+    "name": "collateral_provider_name",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Collateral Provider Agency Type": {
+    "name": "collateral_provider_type",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Security Agent/Collateral Agent": {
+    "name": "collateral_agent_name`",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Security Agent/Collateral Agent Type": {
+    "name": "collateral_agent_type`",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Collateral": {
+    "name": "collateralized",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Amount (Original Currency)": {
+    "name": "value_original_currency",
+    "type": "float64[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Original Currency": {
+    "name": "original_currency",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Amount Estimated": {
+    "name": "value_estimated",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Amount (Constant USD 2021)": {
+    "name": "value_constant_usd_2021",
+    "type": "float64[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Amount (Nominal USD)": {
+    "name": "value_current_usd",
+    "type": "float64[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Adjusted Amount (Original Currency)": {
+    "name": "adjusted_value_original_currency",
+    "type": "float64[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Adjusted Amount (Constant USD 2021)": {
+    "name": "adjusted_value_constant_usd_2021",
+    "type": "float64[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Adjusted Amount (Nominal USD)": {
+    "name": "adjusted_value_current_2021",
+    "type": "float64[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Financial Distress": {
+    "name": "financial_distress",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Commitment Date (MM/DD/YYYY)": {
+    "name": "commitment_date",
+    "type": "date32[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Commitment Date Estimated": {
+    "name": "commitment_date_estimated",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Planned Implementation Start Date (MM/DD/YYYY)": {
+    "name": "planned_implementation_date",
+    "type": "date32[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Actual Implementation Start Date (MM/DD/YYYY)": {
+    "name": "actual_implementation_date",
+    "type": "date32[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Actual Implementation Start Date Estimated": {
+    "name": "actual_implementation_date_estimated",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Deviation from Planned Implementation Start Date": {
+    "name": "deviation_planned_actual_implementation_date",
+    "type": "int32[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Planned Completion Date (MM/DD/YYYY)": {
+    "name": "planned_completion_date",
+    "type": "date32[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Actual Completion Date (MM/DD/YYYY)": {
+    "name": "actual_completion_date",
+    "type": "date32[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Actual Completion Date Estimated": {
+    "name": "actual_completion_date_estimated",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Deviation from Planned Completion Date": {
+    "name": "deviation_planned_actual_completion_date",
+    "type": "int32[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Maturity": {
+    "name": "maturity",
+    "type": "float64[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Interest Rate": {
+    "name": "interest_rate",
+    "type": "float64[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Grace Period": {
+    "name": "grace_period",
+    "type": "float64[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Management Fee": {
+    "name": "management_fee",
+    "type": "float64[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Commitment Fee": {
+    "name": "commitment_fee",
+    "type": "float64[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Insurance Fee (Percent)": {
+    "name": "insurance_fee_percent",
+    "type": "float64[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Insurance Fee (Nominal USD)": {
+    "name": "insurance_fee_current_usd",
+    "type": "float64[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Default Interest Rate": {
+    "name": "default_interest_rate",
+    "type": "float64[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "First Loan Repayment Date": {
+    "name": "first_loan_repayment_date",
+    "type": "date32[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Last Loan Repayment Date": {
+    "name": "last_loan_repayment_date",
+    "type": "date32[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Grant Element (OECD Cash-Flow)": {
+    "name": "grant_element_flow",
+    "type": "float64[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Grant Element (OECD Grant-Equiv)": {
+    "name": "grant_element_grant_equivalent",
+    "type": "float64[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Grant Element (IMF)": {
+    "name": "grant_element_imf",
+    "type": "float64[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Number of Lenders": {
+    "name": "number_of_lenders",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Export Buyer's Credit": {
+    "name": "export_buyers_credit",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Supplier’s Credit/Export Seller’s Credit": {
+    "name": "suppliers_credit_export_sellers_credit",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Interest-Free Loan": {
+    "name": "interest_free_loan",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Refinancing": {
+    "name": "refinancing",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Investment Project Loan": {
+    "name": "investment_project_loan",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "M&A": {
+    "name": "m_a",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Working Capital": {
+    "name": "working_capital",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "EPCF": {
+    "name": "epcf",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Lease": {
+    "name": "Lease",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "FXSL/BOP":  {
+    "name": "fxsl_bop",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "CC IRS": {
+    "name": "cc_irs",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "RCF": {
+    "name": "rcf",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "GCL": {
+    "name": "gcl",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "PBC": {
+    "name": "gcl",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "PxF/Commodity Prepayment": {
+    "name": "pxf_commodity_prepayment",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Inter-Bank Loan": {
+    "name": "inter_bank_loan",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Overseas Project Contracting Loan": {
+    "name": "overseas_project_contracting_loan",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "DPA": {
+    "name": "dpa",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Project Finance": {
+    "name": "project_finance",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Involving Multilateral": {
+    "name": "involving_multilateral",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Non-Chinese Financier": {
+    "name": "non_chinese_financier",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Short-Term": {
+    "name": "short_term",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Rescue": {
+    "name": "rescue",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Project JV/SPV Host Government Ownership": {
+    "name": "project_jv_spv_host_government_ownership",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Project JV/SPV Chinese Government Ownership": {
+    "name": "project_jv_spv_chinese_government_ownership",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Level of Public Liability": {
+    "name": "level_of_public_liability",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Total Source Count": {
+    "name": "total_source_count",
+    "type": "int32[pyarrow]",
+    "keep": false,
+    "bool": false
+  },
+  "Official Source Count": {
+    "name": "official_source_count",
+    "type": "int32[pyarrow]",
+    "keep": false,
+    "bool": false
+  },
+  "Source URLs": {
+    "name": "source_urls",
+    "type": "string[pyarrow]",
+    "keep": false,
+    "bool": false
+  },
+  "Source Titles": {
+    "name": "source_titles",
+    "type": "string[pyarrow]",
+    "keep": false,
+    "bool": false
+  },
+  "Source Publishers": {
+    "name": "source_publishers",
+    "type": "string[pyarrow]",
+    "keep": false,
+    "bool": false
+  },
+  "Source Resource Types": {
+    "name": "source_resource_types",
+    "type": "string[pyarrow]",
+    "keep": false,
+    "bool": false
+  },
+  "Contact Name": {
+    "name": "contact_name",
+    "type": "string[pyarrow]",
+    "keep": false,
+    "bool": false
+  },
+  "Contact Position": {
+    "name": "contact_position",
+    "type": "string[pyarrow]",
+    "keep": false,
+    "bool": false
+  },
+  "ODA Eligible Recipient": {
+    "name": "oda_eligible_recipient",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "OECD ODA Income Group": {
+    "name": "income_group_name",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Location Narrative": {
+    "name": "location_narrative",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Geographic Level of Precision Available": {
+    "name": "geographic_precision_level",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "ADM1 Level Available": {
+    "name": "adm1_level_available",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "ADM2 Level Available": {
+    "name": "adm2_level_available",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Geospatial Feature Available": {
+    "name": "geospatial_feature_available",
+    "type": "string[pyarrow]",
+    "keep": true,
+    "bool": true
+  },
+  "Source Quality Score": {
+    "name": "source_quality",
+    "type": "int32[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Data Completeness Score": {
+    "name": "source_quality",
+    "type": "int32[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Implementation Detail Score": {
+    "name": "implementation_detail",
+    "type": "int32[pyarrow]",
+    "keep": true,
+    "bool": false
+  },
+  "Loan Detail Score": {
+    "name": "implementation_detail",
+    "type": "int32[pyarrow]",
+    "keep": true,
+    "bool": false
+  }
+}

--- a/oda_reader/schemas/schema_tools.py
+++ b/oda_reader/schemas/schema_tools.py
@@ -17,8 +17,13 @@ def read_schema_translation(version: str = "dac1") -> dict:
     """
     logger.info(f"Reading the {version} schema translation")
 
+    if version == "aidData":
+        schema = "schema"
+    else:
+        schema = "dotstat"
+
     # Load the schema translation
-    with open(ImporterPaths.mappings / f"{version}_dotstat.json", "r") as f:
+    with open(ImporterPaths.mappings / f"{version}_{schema}.json", "r") as f:
         mapping = json.load(f)
 
     return mapping
@@ -81,6 +86,24 @@ def get_columns_to_keep(schema: dict) -> list:
             columns_to_keep.append(column)
 
     return columns_to_keep
+
+def get_bool_columns(schema:dict) -> list:
+    """
+    Get the columns bool columns from the schema.
+
+    Args:
+        schema: The schema.
+
+    Returns:
+        list: The bool columns.
+
+    """
+    bool_columns = []
+    for column, settings in schema.items():
+        if settings["bool"]:
+            bool_columns.append(column)
+
+    return bool_columns
 
 
 def map_area_codes(
@@ -172,19 +195,25 @@ def convert_unit_measure_to_amount_type(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def preprocess(df: pd.DataFrame, schema_translation: dict) -> pd.DataFrame:
-    """Preprocess the DAC1 data.
+    """Preprocess the DAC1 or aidData data.
 
     Args:
-        df (pd.DataFrame): The raw DAC1 data, as returned by the API.
-        schema_translation (dict): The schema translation to map the DAC1 API
-        response to the .stat schema.
+        df (pd.DataFrame): The raw data.
+        schema_translation (dict): The schema translation to map.
 
     Returns:
-        pd.DataFrame: The preprocessed DAC1 data.
+        pd.DataFrame: The preprocessed data.
 
     """
     # Preprocess the data
     logger.info("Preprocessing the data")
+
+    # Get bool columns
+    bool_columns = get_bool_columns(schema=schema_translation)
+    # Convert dtypes and
+    if bool_columns:
+        for col in bool_columns:
+            df[col] = df[col].map({"Yes": 1, "No": 0}).astype("int8[pyarrow]")
 
     # Get columns to keep
     to_keep = get_columns_to_keep(schema=schema_translation)


### PR DESCRIPTION
This PR adds or modifies some tools to clean and format AidData after download. More specifically:

- `schemas.mappings.aidData_schema.json` has been added. It contains column names, dtypes, whether to keep the column of not, and whether a column should be converted to boolean. 
- `schema_tools.preprocess()` has been modified to also support preprocessing of aidData. Previously only supported DAC1 data preprocessing. 

This allows the `aiddata` module to use preexisting methods for preprocessing data.