### PR TITLE
Implement streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ and Other Official Flows (OOFs) directly from the OECD API.
 - **Bulk download** microdata from the CRS, the Multisystem dataset, and other datasets.
 - **Schema Translation**: Translate OECD data to `.stat` schema for easier integration.
 - **Multi-version Support**: Access multiple versions of dataflows (CRS, DAC1, DAC2, etc.).
-- **Disk Cache**: Downloaded archives are cached on disk to avoid repeated API calls. Set
-  the `ODA_READER_CACHE_DIR` environment variable to control the cache location.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ and Other Official Flows (OOFs) directly from the OECD API.
 - **Bulk download** microdata from the CRS, the Multisystem dataset, and other datasets.
 - **Schema Translation**: Translate OECD data to `.stat` schema for easier integration.
 - **Multi-version Support**: Access multiple versions of dataflows (CRS, DAC1, DAC2, etc.).
+- **Disk Cache**: Downloaded archives are cached on disk to avoid repeated API calls. Set
+  the `ODA_READER_CACHE_DIR` environment variable to control the cache location.
 
 ## Installation
 
@@ -326,6 +328,9 @@ It accepts a few different arguments:
 saved. If not provided, `bulk_download_crs` will return a Pandas DataFrame.
 - `reduced_version`: A boolean which defaults to `False`. If `True` smaller file (removing certain
 columns) is downloaded and saved/returned instead.
+- `as_iterator`: If `True` the function yields one `DataFrame` per row group
+  instead of returning the entire file at once. This greatly reduces the peak
+  memory usage when working with very large files.
 
 **Note** that the files provided by the OECD follow the .Stat schema.
 
@@ -335,6 +340,16 @@ To save the full parquet file to `example-folder`:
 from oda_reader import bulk_download_crs
 
 bulk_download_crs(save_to_path="./example-folder/")
+```
+
+To process the file iteratively and keep memory usage low:
+
+```python
+from oda_reader import bulk_download_crs
+
+for chunk in bulk_download_crs(as_iterator=True):
+    # process each chunk (a pandas DataFrame)
+    ...
 ```
 
 To keep the full file in memory as a Pandas DataFrame:
@@ -483,12 +498,14 @@ In many situations, downloading the full Multisystem data may be the most effici
 For those cases, ODA Reader provides tools for getting the bulk download files provided by the OECD.
 The entire Multisystem dataset is provided as a parquet file.
 
-The `bulk_download_multisystem()` function allows you to download the full CRS data (as a parquet file).
+The `bulk_download_multisystem()` function allows you to download the full Multisystem data (as a parquet file).
 
-It accepts a single argument:
+It accepts a couple of arguments:
 
 - `save_to_path`: A string or `Path` object specifying a folder where the parquet file should be
   saved. If not provided, `bulk_download_multisystem` will return a Pandas DataFrame.
+- `as_iterator`: If `True` yields `DataFrame` chunks instead of loading the full
+  file into memory at once.
 
 **Note** that the files provided by the OECD follow the .Stat schema.
 
@@ -498,6 +515,16 @@ To save the full parquet file to `example-folder`:
 from oda_reader import bulk_download_multisystem
 
 bulk_download_multisystem(save_to_path="./example-folder/")
+```
+
+To process the data iteratively:
+
+```python
+from oda_reader import bulk_download_multisystem
+
+for chunk in bulk_download_multisystem(as_iterator=True):
+    # process each chunk here
+    ...
 ```
 
 To keep the full file in memory as a Pandas DataFrame:

--- a/oda_reader/common.py
+++ b/oda_reader/common.py
@@ -56,7 +56,7 @@ def _get_dataflow_version(url: str) -> str:
 
 
 @memory().cache
-def _cached_get_response_text(url: str, headers: dict) -> tuple[int, str]:
+def _cached_get_response_text(url: str, headers: tuple) -> tuple[int, str]:
     """Cached GET request returning only the status code and text content.
 
     Args:
@@ -67,7 +67,7 @@ def _cached_get_response_text(url: str, headers: dict) -> tuple[int, str]:
         tuple[int, str]: A tuple containing the status code and text content.
     """
     logger.info(f"Fetching data from {url}")
-    response = requests.get(url, headers=headers)
+    response = requests.get(url, headers=dict(headers))
     return response.status_code, response.text
 
 

--- a/oda_reader/crs.py
+++ b/oda_reader/crs.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pandas as pd
+import typing
 
 from oda_reader._cache import cache_info
 from oda_reader.common import logger
@@ -36,7 +37,12 @@ def get_year_crs_zip_id(year: int):
     )
 
 
-def download_crs_file(year: int | str, save_to_path: Path | str | None = None):
+def download_crs_file(
+    year: int | str,
+    save_to_path: Path | str | None = None,
+    *,
+    as_iterator: bool = False,
+) -> pd.DataFrame | None | typing.Iterator[pd.DataFrame]:
     """
     Download a year of CRS data from the bulk download service. The file is large.
     It is therefore strongly recommended to save it to disk. If save_to_path is not
@@ -46,22 +52,30 @@ def download_crs_file(year: int | str, save_to_path: Path | str | None = None):
         year: The year of CRS data to download.
         save_to_path: The path to save the file to. Optional. If not provided, a
         DataFrame is returned.
+        as_iterator: If ``True`` yields ``DataFrame`` chunks instead of a single
+        ``DataFrame``.
 
     Returns:
-        pd.DataFrame | None: The DataFrame if save_to_path is not provided.
+        pd.DataFrame | Iterator[pd.DataFrame] | None
 
     """
 
     file_id = get_year_crs_zip_id(year=year)
 
     return bulk_download_parquet(
-        file_id=file_id, save_to_path=save_to_path, is_txt=True
+        file_id=file_id,
+        save_to_path=save_to_path,
+        is_txt=True,
+        as_iterator=as_iterator,
     )
 
 
 def bulk_download_crs(
-    save_to_path: Path | str | None = None, reduced_version: bool = False
-):
+    save_to_path: Path | str | None = None,
+    reduced_version: bool = False,
+    *,
+    as_iterator: bool = False,
+) -> pd.DataFrame | None | typing.Iterator[pd.DataFrame]:
     """
     Bulk download the CRS data from the bulk download service. The file is very large.
     It is therefore strongly recommended to save it to disk. If save_to_path is not
@@ -71,9 +85,11 @@ def bulk_download_crs(
         save_to_path: The path to save the file to. Optional. If not provided, a
         DataFrame is returned.
         reduced_version: Whether to download the reduced version of the CRS data.
+        as_iterator: If ``True`` yields ``DataFrame`` chunks instead of a single
+        ``DataFrame``.
 
     Returns:
-        pd.DataFrame | None: The DataFrame if save_to_path is not provided.
+        pd.DataFrame | Iterator[pd.DataFrame] | None
 
     """
 
@@ -82,7 +98,11 @@ def bulk_download_crs(
     else:
         file_id = get_full_crs_parquet_id()
 
-    return bulk_download_parquet(file_id=file_id, save_to_path=save_to_path)
+    return bulk_download_parquet(
+        file_id=file_id,
+        save_to_path=save_to_path,
+        as_iterator=as_iterator,
+    )
 
 
 @cache_info

--- a/oda_reader/download/download_tools.py
+++ b/oda_reader/download/download_tools.py
@@ -1,6 +1,7 @@
 import io
 import os
 import re
+import shutil
 import tempfile
 import zipfile
 from pathlib import Path
@@ -198,11 +199,13 @@ def _save_or_return_parquet_files_from_content(
             save_to_path.mkdir(parents=True, exist_ok=True)
             for file_name in parquet_files:
                 logger.info(f"Saving {file_name}")
+                dest_path = save_to_path / file_name
+                dest_path.parent.mkdir(parents=True, exist_ok=True)
                 with (
                     z.open(file_name) as f_in,
-                    (save_to_path / file_name).open("wb") as f_out,
+                    dest_path.open("wb") as f_out,
                 ):
-                    f_out.write(f_in.read())
+                    shutil.copyfileobj(f_in, f_out, length=1024 * 1024)
             return None
 
         if as_iterator:

--- a/oda_reader/multisystem.py
+++ b/oda_reader/multisystem.py
@@ -1,3 +1,4 @@
+import typing
 from pathlib import Path
 
 import pandas as pd
@@ -21,7 +22,11 @@ def get_full_multisystem_id():
     )
 
 
-def bulk_download_multisystem(save_to_path: Path | str | None = None):
+def bulk_download_multisystem(
+    save_to_path: Path | str | None = None,
+    *,
+    as_iterator: bool = False,
+) -> pd.DataFrame | None | typing.Iterator[pd.DataFrame]:
     """
     Download the Multisystem data from the bulk download service. The file is very large.
     It is therefore strongly recommended to save it to disk. If save_to_path is not
@@ -30,17 +35,22 @@ def bulk_download_multisystem(save_to_path: Path | str | None = None):
     Args:
         save_to_path: The path to save the file to. Optional. If not provided, a
         DataFrame is returned.
+        as_iterator: If `True` yields `DataFrame` chunks instead of a single
+        `DataFrame`.
 
 
     Returns:
-        pd.DataFrame | None: The DataFrame if save_to_path is not provided.
+        pd.DataFrame | Iterator[pd.DataFrame] | None
 
     """
 
     file_id = get_full_multisystem_id()
 
     return bulk_download_parquet(
-        file_id=file_id, save_to_path=save_to_path, is_txt=True
+        file_id=file_id,
+        save_to_path=save_to_path,
+        is_txt=True,
+        as_iterator=as_iterator,
     )
 
 


### PR DESCRIPTION
This PR adds file streaming, chunking, and better management of the raw data to reduce the amount of memory used by downloading and saving the bulk download files. 
* Added the `as_iterator` parameter to `bulk_download_crs` and `bulk_download_multisystem` functions, enabling them to yield `DataFrame` chunks instead of loading entire files into memory. Updated the corresponding method signatures and logic to support this feature
* Refactored file extraction by adding streaming logic with introducing `_open_zip` and `_iter_frames` helper functions.