### PR TITLE
Add rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog for oda_reader
+
+## 1.2.1 (2025-06-10)
+- Introduces rate limiting (20 requests per minute).This is to better manage the OECD's aggressive rate throttling (20 requests per minute).
+
 ## 1.2.0 (2025-06-05)
 - Introduces importer tools for the AidData's Global Chinese development finance dataset.
 - Introduces functionality to stream bulk files to avoid loading too much data to memory

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ ODA Reader is a project created and maintained by The ONE Campaign.
 6. [CRS](#downloading-crs-data)
 7. [Multisystem](#downloading-multisystem-data)
 8. [Using filters](#using-filters)
-9. [Contribute](#contributing-to-oda-reader)
+9. [Rate limiting](#rate-limiting)
+10. [Contribute](#contributing-to-oda-reader)
 
 ## Getting Started
 
@@ -40,6 +41,7 @@ and Other Official Flows (OOFs) directly from the OECD API.
 - **Bulk download** microdata from the CRS, the Multisystem dataset, and other datasets.
 - **Schema Translation**: Translate OECD data to `.stat` schema for easier integration.
 - **Multi-version Support**: Access multiple versions of dataflows (CRS, DAC1, DAC2, etc.).
+- **Rate Limiting**: API calls automatically pause when the limit (20 requests per minute by default) is reached.
 
 ## Installation
 
@@ -571,6 +573,19 @@ crs_filters = get_available_filters(source="crs")
 multisystem_filters = get_available_filters(source="multisystem")
 ```
 
+
+## Rate limiting
+
+ODA Reader limits outgoing requests to avoid hitting the OECD API too often.
+Network calls pause automatically when the limit (20 calls per minute by default)
+is reached. The limit can be changed via the ``API_RATE_LIMITER`` object:
+
+```python
+from oda_reader import API_RATE_LIMITER
+
+API_RATE_LIMITER.max_calls = 10
+API_RATE_LIMITER.period = 60
+```
 
 ## Contributing to ODA Reader
 

--- a/oda_reader/__init__.py
+++ b/oda_reader/__init__.py
@@ -20,6 +20,7 @@ from oda_reader.multisystem import download_multisystem, bulk_download_multisyst
 from oda_reader.crs import download_crs, bulk_download_crs, download_crs_file
 from oda_reader.aiddata import download_aiddata
 from oda_reader.tools import get_available_filters
+from oda_reader.common import API_RATE_LIMITER
 
 enforce_cache_limits()
 
@@ -41,4 +42,5 @@ __all__ = [
     "clear_cache",
     "set_cache_dir",
     "cache_dir",
+    "API_RATE_LIMITER",
 ]

--- a/oda_reader/download/download_tools.py
+++ b/oda_reader/download/download_tools.py
@@ -19,6 +19,7 @@ from oda_reader.common import (
     _cached_get_response_text,
     _get_response_text,
     _cached_get_response_content,
+    API_RATE_LIMITER,
 )
 from oda_reader.download.query_builder import QueryBuilder
 from oda_reader.schemas.crs_translation import convert_crs_to_dotstat_codes
@@ -317,6 +318,7 @@ def _stream_to_file(url: str, headers: dict, path: Path) -> None:
     """Stream a URL to the given file path."""
 
     logger.info(f"Streaming download from {url}")
+    API_RATE_LIMITER.wait()
     with requests.get(url, headers=headers, stream=True) as r:
         if r.status_code > 299:
             raise ConnectionError(f"Error {r.status_code}: {r.text}")

--- a/oda_reader/schemas/xml_tools.py
+++ b/oda_reader/schemas/xml_tools.py
@@ -4,7 +4,7 @@ from xml.etree import ElementTree as ET
 
 import requests
 
-from oda_reader.common import logger
+from oda_reader.common import logger, API_RATE_LIMITER
 
 
 def download_xml(xml_url: str) -> requests.models.Response:
@@ -19,6 +19,7 @@ def download_xml(xml_url: str) -> requests.models.Response:
     logger.info(f"Downloading XML file from {xml_url}")
 
     # Get file with requests
+    API_RATE_LIMITER.wait()
     response = requests.get(xml_url)
 
     # Check if the request was successful


### PR DESCRIPTION
This pull request introduces a rate-limiting mechanism to the `oda_reader` library to manage API call limits effectively and prevent exceeding the OECD API's restrictions. The changes include adding a `RateLimiter` class, integrating it into API-related functions, and updating documentation to reflect this new functionality.

* **Rate Limiter Implementation**: Added a `RateLimiter` class in `oda_reader/common.py` to enforce a limit of 20 API calls per minute by default. The `wait` method blocks execution when the limit is reached.
* **Global Rate Limiter Integration**: Integrated the `RateLimiter` (`API_RATE_LIMITER`) into all API-related functions, such as `_cached_get_response_text`, `_get_response_content`, `_get_response_text`, `_get_response_content`, and `_stream_to_file`. These functions now pause execution when the limit is reached. 
