### PR TITLE
Add bulk download 2a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog for oda_reader
 
+## 1.4.0 (2025-12-19)
+- Adds `bulk_download_dac2a()` function for bulk downloading the full DAC2A dataset.
+- Auto-detects file types (parquet vs txt/csv) in bulk downloads, removing the need for the `is_txt` parameter.
+- Auto-detects CSV delimiters (comma, pipe, tab, semicolon) when reading txt files from bulk downloads.
+- Deprecates the `is_txt` parameter in `bulk_download_parquet()`. The parameter is still accepted for backward compatibility but emits a deprecation warning and will be removed in a future major release.
+- Adds pytest and pytest-mock to dev dependencies for improved testing support.
+
 ## 1.3.5 (2025-12-19)
 - Fixes `_get_dataflow_version()` to gracefully handle URLs without a version pattern instead of crashing.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oda_reader"
-version = "1.3.5"
+version = "1.4.0"
 description = "A simple package to import ODA data from the OECD's API and AidData's database"
 readme = "README.md"
 license = "MIT"
@@ -42,6 +42,8 @@ build-backend = "uv_build"
 [dependency-groups]
 dev = [
     "pre-commit>=4.0.0",
+    "pytest>=9.0.2",
+    "pytest-mock>=3.15.1",
     "ruff>=0.14.0",
 ]
 docs = [

--- a/src/oda_reader/__init__.py
+++ b/src/oda_reader/__init__.py
@@ -28,7 +28,7 @@ from oda_reader.common import (
 )
 from oda_reader.crs import bulk_download_crs, download_crs, download_crs_file
 from oda_reader.dac1 import download_dac1
-from oda_reader.dac2a import download_dac2a
+from oda_reader.dac2a import bulk_download_dac2a, download_dac2a
 from oda_reader.download.query_builder import QueryBuilder
 from oda_reader.multisystem import bulk_download_multisystem, download_multisystem
 from oda_reader.tools import get_available_filters
@@ -38,6 +38,7 @@ __all__ = [
     "QueryBuilder",
     "download_dac1",
     "download_dac2a",
+    "bulk_download_dac2a",
     "download_multisystem",
     "bulk_download_multisystem",
     "download_crs",

--- a/src/oda_reader/crs.py
+++ b/src/oda_reader/crs.py
@@ -62,7 +62,6 @@ def download_crs_file(
     return bulk_download_parquet(
         file_id=file_id,
         save_to_path=save_to_path,
-        is_txt=True,
         as_iterator=as_iterator,
     )
 

--- a/src/oda_reader/multisystem.py
+++ b/src/oda_reader/multisystem.py
@@ -47,7 +47,6 @@ def bulk_download_multisystem(
     return bulk_download_parquet(
         file_id=file_id,
         save_to_path=save_to_path,
-        is_txt=True,
         as_iterator=as_iterator,
     )
 

--- a/tests/datasets/dac2a/unit/test_dac2a_bulk.py
+++ b/tests/datasets/dac2a/unit/test_dac2a_bulk.py
@@ -1,0 +1,98 @@
+"""Unit tests for DAC2a bulk download functionality."""
+
+import pytest
+
+from oda_reader.dac2a import bulk_download_dac2a, get_full_dac2a_parquet_id
+
+
+@pytest.mark.unit
+class TestDAC2aBulkDownload:
+    """Test DAC2a bulk download functions with mocked dependencies."""
+
+    def test_get_full_dac2a_parquet_id_calls_correct_function(self, mocker):
+        """Test that get_full_dac2a_parquet_id calls get_bulk_file_id with correct params."""
+        mock_get_bulk = mocker.patch(
+            "oda_reader.dac2a.get_bulk_file_id",
+            return_value="test-file-id-123",
+        )
+
+        result = get_full_dac2a_parquet_id()
+
+        assert result == "test-file-id-123"
+        mock_get_bulk.assert_called_once()
+        # Verify the flow URL contains DAC2A
+        call_kwargs = mock_get_bulk.call_args.kwargs
+        assert "DAC2A" in call_kwargs["flow_url"]
+        # Verify the search string is for DAC2A full dataset
+        assert "DAC2A full dataset" in call_kwargs["search_string"]
+
+    def test_bulk_download_dac2a_returns_dataframe(self, mocker):
+        """Test that bulk_download_dac2a returns DataFrame when no save path."""
+        import pandas as pd
+
+        mock_df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+
+        mocker.patch(
+            "oda_reader.dac2a.get_full_dac2a_parquet_id",
+            return_value="mock-file-id",
+        )
+        mock_bulk = mocker.patch(
+            "oda_reader.dac2a.bulk_download_parquet",
+            return_value=mock_df,
+        )
+
+        result = bulk_download_dac2a()
+
+        assert result is mock_df
+        mock_bulk.assert_called_once_with(
+            file_id="mock-file-id",
+            save_to_path=None,
+            as_iterator=False,
+        )
+
+    def test_bulk_download_dac2a_saves_to_path(self, mocker, tmp_path):
+        """Test that bulk_download_dac2a passes save path to underlying function."""
+        mocker.patch(
+            "oda_reader.dac2a.get_full_dac2a_parquet_id",
+            return_value="mock-file-id",
+        )
+        mock_bulk = mocker.patch(
+            "oda_reader.dac2a.bulk_download_parquet",
+            return_value=None,
+        )
+
+        result = bulk_download_dac2a(save_to_path=tmp_path)
+
+        assert result is None
+        mock_bulk.assert_called_once_with(
+            file_id="mock-file-id",
+            save_to_path=tmp_path,
+            as_iterator=False,
+        )
+
+    def test_bulk_download_dac2a_as_iterator(self, mocker):
+        """Test that bulk_download_dac2a passes as_iterator flag correctly."""
+        import pandas as pd
+
+        def mock_iterator():
+            yield pd.DataFrame({"col1": [1]})
+            yield pd.DataFrame({"col1": [2]})
+
+        mocker.patch(
+            "oda_reader.dac2a.get_full_dac2a_parquet_id",
+            return_value="mock-file-id",
+        )
+        mock_bulk = mocker.patch(
+            "oda_reader.dac2a.bulk_download_parquet",
+            return_value=mock_iterator(),
+        )
+
+        result = bulk_download_dac2a(as_iterator=True)
+
+        # Result should be an iterator
+        assert hasattr(result, "__iter__")
+        mock_bulk.assert_called_once_with(
+            file_id="mock-file-id",
+            save_to_path=None,
+            as_iterator=True,
+        )

--- a/tests/download/unit/test_download_tools.py
+++ b/tests/download/unit/test_download_tools.py
@@ -1,8 +1,18 @@
 """Unit tests for download tools with mocked API responses."""
 
+import io
+import warnings
+import zipfile
+
+import pandas as pd
 import pytest
 
 from oda_reader.common import get_data_from_api
+from oda_reader.download.download_tools import (
+    _detect_delimiter,
+    _save_or_return_parquet_files_from_content,
+    bulk_download_parquet,
+)
 
 
 @pytest.mark.unit
@@ -55,3 +65,221 @@ class TestDownloadWithMocks:
 
         with pytest.raises(ConnectionError, match="Error 500"):
             get_data_from_api("https://example.com/data")
+
+
+@pytest.mark.unit
+class TestDetectDelimiter:
+    """Test delimiter detection for CSV/txt files."""
+
+    def test_detect_comma_delimiter(self):
+        """Test that comma-delimited content is detected correctly."""
+        csv_content = "col1,col2,col3\nval1,val2,val3\nval4,val5,val6"
+        file_obj = io.BytesIO(csv_content.encode("utf-8"))
+
+        delimiter = _detect_delimiter(file_obj)
+
+        assert delimiter == ","
+        # Verify file position was reset
+        assert file_obj.tell() == 0
+
+    def test_detect_pipe_delimiter(self):
+        """Test that pipe-delimited content is detected correctly."""
+        csv_content = "col1|col2|col3\nval1|val2|val3\nval4|val5|val6"
+        file_obj = io.BytesIO(csv_content.encode("utf-8"))
+
+        delimiter = _detect_delimiter(file_obj)
+
+        assert delimiter == "|"
+        assert file_obj.tell() == 0
+
+    def test_detect_tab_delimiter(self):
+        """Test that tab-delimited content is detected correctly."""
+        csv_content = "col1\tcol2\tcol3\nval1\tval2\tval3"
+        file_obj = io.BytesIO(csv_content.encode("utf-8"))
+
+        delimiter = _detect_delimiter(file_obj)
+
+        assert delimiter == "\t"
+        assert file_obj.tell() == 0
+
+    def test_comma_wins_when_ambiguous(self):
+        """Test that comma is preferred when sniffing fails and counts are equal."""
+        # Content with no clear delimiter
+        csv_content = "just some text without clear delimiters"
+        file_obj = io.BytesIO(csv_content.encode("utf-8"))
+
+        delimiter = _detect_delimiter(file_obj)
+
+        # Should default to comma when counts are equal (both 0)
+        assert delimiter == ","
+
+    def test_works_with_string_io(self):
+        """Test that delimiter detection works with StringIO objects too."""
+        csv_content = "col1;col2;col3\nval1;val2;val3"
+        file_obj = io.StringIO(csv_content)
+
+        delimiter = _detect_delimiter(file_obj)
+
+        assert delimiter == ";"
+        assert file_obj.tell() == 0
+
+
+@pytest.mark.unit
+class TestFileTypeAutoDetection:
+    """Test automatic file type detection in zip archives."""
+
+    def _create_zip_with_parquet(self) -> bytes:
+        """Create a zip file containing a parquet file."""
+        df = pd.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]})
+        parquet_buffer = io.BytesIO()
+        df.to_parquet(parquet_buffer)
+
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, "w") as z:
+            z.writestr("test_data.parquet", parquet_buffer.getvalue())
+        return zip_buffer.getvalue()
+
+    def _create_zip_with_txt(self, delimiter: str = ",") -> bytes:
+        """Create a zip file containing a txt/CSV file."""
+        if delimiter == "|":
+            csv_content = "col1|col2|col3\n1|2|3\n4|5|6"
+        else:
+            csv_content = "col1,col2,col3\n1,2,3\n4,5,6"
+
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, "w") as z:
+            z.writestr("test_data.txt", csv_content.encode("utf-8"))
+        return zip_buffer.getvalue()
+
+    def test_auto_detect_parquet_files(self):
+        """Test that parquet files are auto-detected and read correctly."""
+        zip_content = self._create_zip_with_parquet()
+
+        result = _save_or_return_parquet_files_from_content(zip_content)
+
+        assert result is not None
+        assert len(result) == 1
+        assert isinstance(result[0], pd.DataFrame)
+        assert list(result[0].columns) == ["col1", "col2"]
+        assert len(result[0]) == 3
+
+    def test_auto_detect_txt_files_comma(self):
+        """Test that comma-delimited txt files are auto-detected."""
+        zip_content = self._create_zip_with_txt(delimiter=",")
+
+        result = _save_or_return_parquet_files_from_content(zip_content)
+
+        assert result is not None
+        assert len(result) == 1
+        assert isinstance(result[0], pd.DataFrame)
+        assert list(result[0].columns) == ["col1", "col2", "col3"]
+
+    def test_auto_detect_txt_files_pipe(self):
+        """Test that pipe-delimited txt files are auto-detected."""
+        zip_content = self._create_zip_with_txt(delimiter="|")
+
+        result = _save_or_return_parquet_files_from_content(zip_content)
+
+        assert result is not None
+        assert len(result) == 1
+        df = result[0]
+        assert isinstance(df, pd.DataFrame)
+        assert list(df.columns) == ["col1", "col2", "col3"]
+        assert len(df) == 2
+
+    def test_save_parquet_to_path(self, tmp_path):
+        """Test saving parquet files to a path."""
+        zip_content = self._create_zip_with_parquet()
+
+        result = _save_or_return_parquet_files_from_content(
+            zip_content, save_to_path=tmp_path
+        )
+
+        assert result is None
+        saved_files = list(tmp_path.glob("*.parquet"))
+        assert len(saved_files) == 1
+        # Verify the saved file can be read
+        df = pd.read_parquet(saved_files[0])
+        assert len(df) == 3
+
+    def test_save_txt_as_parquet_to_path(self, tmp_path):
+        """Test that txt files are converted to parquet when saving."""
+        zip_content = self._create_zip_with_txt()
+
+        result = _save_or_return_parquet_files_from_content(
+            zip_content, save_to_path=tmp_path
+        )
+
+        assert result is None
+        saved_files = list(tmp_path.glob("*.parquet"))
+        assert len(saved_files) == 1
+        # Verify conversion to parquet
+        assert saved_files[0].suffix == ".parquet"
+        df = pd.read_parquet(saved_files[0])
+        assert len(df) == 2
+
+    def test_raises_on_empty_zip(self):
+        """Test that ValueError is raised when zip has no valid files."""
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, "w") as z:
+            z.writestr("readme.md", "Not a data file")
+
+        with pytest.raises(ValueError, match="No parquet or txt files"):
+            _save_or_return_parquet_files_from_content(zip_buffer.getvalue())
+
+    def test_txt_iterator_raises(self):
+        """Test that as_iterator raises for txt files."""
+        zip_content = self._create_zip_with_txt()
+
+        with pytest.raises(ValueError, match="Streaming not supported"):
+            _save_or_return_parquet_files_from_content(zip_content, as_iterator=True)
+
+
+@pytest.mark.unit
+class TestDeprecationWarnings:
+    """Test deprecation warnings for backward compatibility."""
+
+    def test_is_txt_parameter_emits_deprecation_warning(self, mocker):
+        """Test that using is_txt parameter emits a deprecation warning."""
+        # Mock the internal functions to avoid actual downloads
+        mocker.patch(
+            "oda_reader.download.download_tools._get_temp_file",
+            return_value=("/fake/path", False),
+        )
+        mocker.patch(
+            "oda_reader.download.download_tools._save_or_return_parquet_files_from_content",
+            return_value=[pd.DataFrame({"col": [1, 2]})],
+        )
+
+        with pytest.warns(DeprecationWarning, match="is_txt.*deprecated"):
+            bulk_download_parquet("fake-id", is_txt=True)
+
+    def test_is_txt_false_also_emits_warning(self, mocker):
+        """Test that is_txt=False also emits deprecation warning."""
+        mocker.patch(
+            "oda_reader.download.download_tools._get_temp_file",
+            return_value=("/fake/path", False),
+        )
+        mocker.patch(
+            "oda_reader.download.download_tools._save_or_return_parquet_files_from_content",
+            return_value=[pd.DataFrame({"col": [1, 2]})],
+        )
+
+        with pytest.warns(DeprecationWarning, match="is_txt.*deprecated"):
+            bulk_download_parquet("fake-id", is_txt=False)
+
+    def test_no_warning_when_is_txt_not_provided(self, mocker):
+        """Test that no warning is emitted when is_txt is not provided."""
+        mocker.patch(
+            "oda_reader.download.download_tools._get_temp_file",
+            return_value=("/fake/path", False),
+        )
+        mocker.patch(
+            "oda_reader.download.download_tools._save_or_return_parquet_files_from_content",
+            return_value=[pd.DataFrame({"col": [1, 2]})],
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            # Should not raise any DeprecationWarning
+            bulk_download_parquet("fake-id")

--- a/uv.lock
+++ b/uv.lock
@@ -789,7 +789,7 @@ wheels = [
 
 [[package]]
 name = "oda-reader"
-version = "1.3.4"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },
@@ -805,6 +805,8 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-mock" },
     { name = "ruff" },
 ]
 docs = [
@@ -834,6 +836,8 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = ">=4.0.0" },
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "ruff", specifier = ">=0.14.0" },
 ]
 docs = [


### PR DESCRIPTION
This pull request introduces several enhancements and improvements to the `oda_reader` package, focusing on bulk downloading and reading of the DAC2A dataset, automatic file type and delimiter detection, and improved developer experience. The most significant changes are the addition of the `bulk_download_dac2a()` function, auto-detection of file types and delimiters, and deprecation of the `is_txt` parameter. Testing support is also improved with new dependencies and unit tests.

### DAC2A Bulk Download Improvements
* Added the `bulk_download_dac2a()` function to enable bulk downloading of the full DAC2A dataset, with support for saving to disk or streaming as an iterator. (`src/oda_reader/dac2a.py`, `src/oda_reader/__init__.py`, [[1]](diffhunk://#diff-5f4a9973cac1ec865bcc356058b74b56f9b756841e82a47c7b1edf11ec5e0b7fL31-R31) [[2]](diffhunk://#diff-5f4a9973cac1ec865bcc356058b74b56f9b756841e82a47c7b1edf11ec5e0b7fR41) [[3]](diffhunk://#diff-ae21abd6312da1cefea8976729e3c35203b9dc99a427502b36ee340d03d3ead4R1-R35) [[4]](diffhunk://#diff-ae21abd6312da1cefea8976729e3c35203b9dc99a427502b36ee340d03d3ead4R80-R106)
* Implemented the `get_full_dac2a_parquet_id()` helper to retrieve the correct file ID for the DAC2A bulk download. (`src/oda_reader/dac2a.py`, [src/oda_reader/dac2a.pyR1-R35](diffhunk://#diff-ae21abd6312da1cefea8976729e3c35203b9dc99a427502b36ee340d03d3ead4R1-R35))
* Added comprehensive unit tests for DAC2A bulk download logic using pytest and pytest-mock. (`tests/datasets/dac2a/unit/test_dac2a_bulk.py`, [tests/datasets/dac2a/unit/test_dac2a_bulk.pyR1-R98](diffhunk://#diff-da5d903755eb35a0cf279fcf7216b683c6b9a753eecaf4be6b33d8f3ac2263a6R1-R98))

### File Type and Delimiter Auto-Detection
* Enhanced bulk download logic to auto-detect file types (parquet vs txt/csv) in zip archives, removing the need for the `is_txt` parameter and supporting both formats transparently. (`src/oda_reader/download/download_tools.py`, [[1]](diffhunk://#diff-c38f5a5738f524172e0bb6b8185ac4e92349e4f6bc683e000d43bb811f9766a3L196-R245) [[2]](diffhunk://#diff-c38f5a5738f524172e0bb6b8185ac4e92349e4f6bc683e000d43bb811f9766a3R255-R258) [[3]](diffhunk://#diff-c38f5a5738f524172e0bb6b8185ac4e92349e4f6bc683e000d43bb811f9766a3R279-R330) [[4]](diffhunk://#diff-c38f5a5738f524172e0bb6b8185ac4e92349e4f6bc683e000d43bb811f9766a3L256-R344) [[5]](diffhunk://#diff-c38f5a5738f524172e0bb6b8185ac4e92349e4f6bc683e000d43bb811f9766a3L279-R383) [[6]](diffhunk://#diff-c38f5a5738f524172e0bb6b8185ac4e92349e4f6bc683e000d43bb811f9766a3L400-R526) [[7]](diffhunk://#diff-c38f5a5738f524172e0bb6b8185ac4e92349e4f6bc683e000d43bb811f9766a3L433-R540)
* Added `_detect_delimiter()` utility to automatically detect CSV delimiters (comma, pipe, tab, semicolon) when reading txt files from bulk downloads. (`src/oda_reader/download/download_tools.py`, [src/oda_reader/download/download_tools.pyR55-R84](diffhunk://#diff-c38f5a5738f524172e0bb6b8185ac4e92349e4f6bc683e000d43bb811f9766a3R55-R84))

### API Changes and Deprecations
* Deprecated the `is_txt` parameter in `bulk_download_parquet()`, emitting a warning when used and updating documentation to reflect auto-detection. (`src/oda_reader/download/download_tools.py`, [src/oda_reader/download/download_tools.pyL400-R526](diffhunk://#diff-c38f5a5738f524172e0bb6b8185ac4e92349e4f6bc683e000d43bb811f9766a3L400-R526))
* Updated usages of `bulk_download_parquet()` in other modules to remove the `is_txt` argument. (`src/oda_reader/crs.py`, [[1]](diffhunk://#diff-b676eabbdcd99134793336314b2faf70c4ef42e6e4e71300eb2d44f0c39181d9L65); `src/oda_reader/multisystem.py`, [[2]](diffhunk://#diff-a7e6996fa5a0a2e3bd311bf60f7b431b1126772613b187cee0ca9c73bdcf4be5L50)

### Developer Experience and Testing
* Added `pytest` and `pytest-mock` to development dependencies for improved testing support. (`pyproject.toml`, [pyproject.tomlR45-R46](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R45-R46))
* Updated the changelog and project version to `1.4.0` to reflect new features and changes. (`CHANGELOG.md`, [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R9); `pyproject.toml`, [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3)

---

**References:**  
[[1]](diffhunk://#diff-5f4a9973cac1ec865bcc356058b74b56f9b756841e82a47c7b1edf11ec5e0b7fL31-R31) [[2]](diffhunk://#diff-5f4a9973cac1ec865bcc356058b74b56f9b756841e82a47c7b1edf11ec5e0b7fR41) [[3]](diffhunk://#diff-ae21abd6312da1cefea8976729e3c35203b9dc99a427502b36ee340d03d3ead4R1-R35) [[4]](diffhunk://#diff-ae21abd6312da1cefea8976729e3c35203b9dc99a427502b36ee340d03d3ead4R80-R106) [[5]](diffhunk://#diff-da5d903755eb35a0cf279fcf7216b683c6b9a753eecaf4be6b33d8f3ac2263a6R1-R98) [[6]](diffhunk://#diff-c38f5a5738f524172e0bb6b8185ac4e92349e4f6bc683e000d43bb811f9766a3L196-R245) [[7]](diffhunk://#diff-c38f5a5738f524172e0bb6b8185ac4e92349e4f6bc683e000d43bb811f9766a3R255-R258) [[8]](diffhunk://#diff-c38f5a5738f524172e0bb6b8185ac4e92349e4f6bc683e000d43bb811f9766a3R279-R330) [[9]](diffhunk://#diff-c38f5a5738f524172e0bb6b8185ac4e92349e4f6bc683e000d43bb811f9766a3L256-R344) [[10]](diffhunk://#diff-c38f5a5738f524172e0bb6b8185ac4e92349e4f6bc683e000d43bb811f9766a3L279-R383) [[11]](diffhunk://#diff-c38f5a5738f524172e0bb6b8185ac4e92349e4f6bc683e000d43bb811f9766a3L400-R526) [[12]](diffhunk://#diff-c38f5a5738f524172e0bb6b8185ac4e92349e4f6bc683e000d43bb811f9766a3L433-R540) [[13]](diffhunk://#diff-c38f5a5738f524172e0bb6b8185ac4e92349e4f6bc683e000d43bb811f9766a3R55-R84) [[14]](diffhunk://#diff-b676eabbdcd99134793336314b2faf70c4ef42e6e4e71300eb2d44f0c39181d9L65) [[15]](diffhunk://#diff-a7e6996fa5a0a2e3bd311bf60f7b431b1126772613b187cee0ca9c73bdcf4be5L50) [[16]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R45-R46) [[17]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R9) [[18]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3)