### PR TITLE
extend to .csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog for oda_reader
 
+## 1.4.1 (2025-12-19)
+- Extends bulk download auto-detection to support `.csv` files in addition to `.txt` files.
+
 ## 1.4.0 (2025-12-19)
 - Adds `bulk_download_dac2a()` function for bulk downloading the full DAC2A dataset.
-- Auto-detects file types (parquet vs txt/csv) in bulk downloads, removing the need for the `is_txt` parameter.
+- Auto-detects file types (parquet or txt) in bulk downloads, removing the need for the `is_txt` parameter.
 - Auto-detects CSV delimiters (comma, pipe, tab, semicolon) when reading txt files from bulk downloads.
 - Deprecates the `is_txt` parameter in `bulk_download_parquet()`. The parameter is still accepted for backward compatibility but emits a deprecation warning and will be removed in a future major release.
 - Adds pytest and pytest-mock to dev dependencies for improved testing support.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oda_reader"
-version = "1.4.0"
+version = "1.4.1"
 description = "A simple package to import ODA data from the OECD's API and AidData's database"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -789,7 +789,7 @@ wheels = [
 
 [[package]]
 name = "oda-reader"
-version = "1.4.0"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
This pull request extends the bulk download functionality to support `.csv` files in addition to `.txt` files. The main change is that the code now automatically detects and processes `.csv` files alongside `.txt` files during bulk downloads, including proper delimiter detection and conversion to parquet format when saving. The tests have also been updated to ensure correct handling of `.csv` files.

**Bulk download enhancements:**

* Updated `_save_or_return_parquet_files_from_content` and `_save_or_return_parquet_files_from_txt_in_zip` in `src/oda_reader/download/download_tools.py` to auto-detect and process both `.csv` and `.txt` files, including proper delimiter detection and conversion to parquet. [[1]](diffhunk://#diff-c38f5a5738f524172e0bb6b8185ac4e92349e4f6bc683e000d43bb811f9766a3L229-R238) [[2]](diffhunk://#diff-c38f5a5738f524172e0bb6b8185ac4e92349e4f6bc683e000d43bb811f9766a3L255-R259) [[3]](diffhunk://#diff-c38f5a5738f524172e0bb6b8185ac4e92349e4f6bc683e000d43bb811f9766a3L279-R294) [[4]](diffhunk://#diff-c38f5a5738f524172e0bb6b8185ac4e92349e4f6bc683e000d43bb811f9766a3L302-R311) [[5]](diffhunk://#diff-c38f5a5738f524172e0bb6b8185ac4e92349e4f6bc683e000d43bb811f9766a3L320-R334) [[6]](diffhunk://#diff-c38f5a5738f524172e0bb6b8185ac4e92349e4f6bc683e000d43bb811f9766a3L344-R366) [[7]](diffhunk://#diff-c38f5a5738f524172e0bb6b8185ac4e92349e4f6bc683e000d43bb811f9766a3L504-R518)

**Testing improvements:**

* Added new tests in `tests/download/unit/test_download_tools.py` to verify auto-detection, reading, and saving of `.csv` files, including different delimiters and conversion to parquet. [[1]](diffhunk://#diff-665e04e9498690eeb0704e68ce374af8d0be2768e3d33b73237cc0eb78943d05R154-R165) [[2]](diffhunk://#diff-665e04e9498690eeb0704e68ce374af8d0be2768e3d33b73237cc0eb78943d05R202-R243)

**Documentation and metadata updates:**

* Updated the changelog in `CHANGELOG.md` to record `.csv` file support and clarified descriptions.
* Bumped the package version to `1.4.1` in `pyproject.toml`.

**Error handling:**

* Improved error messages to reflect the inclusion of `.csv` files when no supported files are found in the archive. [[1]](diffhunk://#diff-c38f5a5738f524172e0bb6b8185ac4e92349e4f6bc683e000d43bb811f9766a3L320-R334) [[2]](diffhunk://#diff-665e04e9498690eeb0704e68ce374af8d0be2768e3d33b73237cc0eb78943d05L227-R281)